### PR TITLE
ENH: Set C99 conformance requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ set(Teem_VERSION_MAJOR "1")
 set(Teem_VERSION_MINOR "12")
 set(Teem_VERSION_PATCH "0")
 
+# Set the C standard to C11 for all targets in this directory
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
 # Version string (no space in version numbers, so doesn't have to be quoted)
 set(Teem_VERSION_STRING ${Teem_VERSION_MAJOR}.${Teem_VERSION_MINOR}.${Teem_VERSION_PATCH})
 

--- a/src/CODING.txt
+++ b/src/CODING.txt
@@ -268,7 +268,7 @@ common in Teem, and adding their protoypes would be onerous (and for similar
 reasons -Wmissing-declarations is not helpful).  So what has proven useful for
 development is:
 
-  gcc -O2 -std=c89 -pedantic \
+  gcc -O2 -std=c99 -pedantic \
    -W -Wall -Wextra -Wno-long-long -Wno-overlength-strings \
    -fstrict-aliasing -Wstrict-aliasing=2 -fstrict-overflow -Wstrict-overflow=5 \
    -ftrapv -fshort-enums -fno-common \


### PR DESCRIPTION
The code base uses idioms that are officially added in c99 standard.  Explicitly check for c99 conformance.  Prefer to trigger warnings or errors when features not available in the c99 standard are used.